### PR TITLE
Issue #12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Publish Docker Image to Github Packages on Release
 on:
   release:
     types:
-      - created
+      - published
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -31,5 +31,5 @@ jobs:
           push: true
           platforms: linux/amd64, linux/arm64
           tags:  ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.label }}
+          labels: ${{ steps.meta.outputs.labels }}
 


### PR DESCRIPTION
release.yml that builds and publishes Docker image to GitHub packages on release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to build and publish Docker images to the container registry whenever a release is published.
  * Produces and pushes multi-architecture images (amd64, arm64) and applies dynamic tags and labels derived from the release metadata for consistent image versioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->