### PR TITLE
Resolve port: CLI > config > default

### DIFF
--- a/PortConfigurationGuide.md
+++ b/PortConfigurationGuide.md
@@ -1,38 +1,49 @@
-# Konfiguration: port (config-fil → default)
+# Konfiguration: port (CLI → config-fil → default)
 
 Det här projektet väljer vilken port servern ska starta på enligt följande prioritet:
- 
-1. **Config-fil** (`application.yml` : `server.port`)  
-2. **Default** (`8080`) - – används om port saknas i config eller om config-filen saknas
 
+1. **CLI-argument** (`--port <port>`) – högst prioritet
+2. **Config-fil** (`application.yml`: `server.port`)
+3. **Default** (`8080`) – används om port saknas i config eller om config-filen saknas
 
 ---
 
 ## 1) Default-värde
 
-Om config-fil saknas, eller om `server.port` inte är satt, används:
+Om varken CLI eller config anger port används:
 
-- **8080** (default för `server.port` i `AppConfig`.)
+- **8080** (default för `server.port` i `AppConfig`)
 
 ---
 
-### 2) Config-fil: `application.yml`
+## 2) Config-fil: `application.yml`
 
 ### Var ska filen ligga?
 Standard:
 - `src/main/resources/application.yml`
 
-
 ### Exempel
-
-yaml server:
-port:9090
+```yaml
+server:
+port: 9090
+```
 
 ---
 
-## 3) Sammanfattning
+## 3) CLI-argument
+
+CLI kan användas för att override:a config:
+
+```bash
+java -cp target/classes org.example.App --port 8000
+```
+
+---
+
+## 4) Sammanfattning
 
 Prioritet:
 
-1. `application.yml` (`server.port`)
-2. Default (`8080`)
+1. CLI (`--port`)
+2. `application.yml` (`server.port`)
+3. Default (`8080`)

--- a/src/main/java/org/example/App.java
+++ b/src/main/java/org/example/App.java
@@ -6,13 +6,50 @@ import org.example.config.ConfigLoader;
 import java.nio.file.Path;
 
 public class App {
+
+    private static final String PORT_FLAG = "--port";
+
     public static void main(String[] args) {
         Path configPath = Path.of("src/main/resources/application.yml");
 
         AppConfig appConfig = ConfigLoader.loadOnce(configPath);
 
-        int port = appConfig.server().port();
+        int port = resolvePort(args, appConfig.server().port());
 
         new TcpServer(port).start();
+    }
+
+    static int resolvePort(String[] args, int configPort) {
+        Integer cliPort = parsePortFromCli(args);
+        if (cliPort != null) {
+            return validatePort(cliPort, "CLI argument " + PORT_FLAG);
+        }
+        return validatePort(configPort, "configuration server.port");
+    }
+
+    static Integer parsePortFromCli(String[] args) {
+        if (args == null) return null;
+
+        for (int i = 0; i < args.length; i++) {
+            if (PORT_FLAG.equals(args[i])) {
+                int valueIndex = i + 1;
+                if (valueIndex >= args.length) {
+                    throw new IllegalArgumentException("Missing value after " + PORT_FLAG);
+                }
+                try {
+                    return Integer.parseInt(args[valueIndex]);
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException("Invalid port value after " + PORT_FLAG + ": " + args[valueIndex], e);
+                }
+            }
+        }
+        return null;
+    }
+
+    static int validatePort(int port, String source) {
+        if (port < 1 || port > 65535) {
+            throw new IllegalArgumentException("Port out of range (1-65535) from " + source + ": " + port);
+        }
+        return port;
     }
 }

--- a/src/test/java/org/example/AppPortResolutionTest.java
+++ b/src/test/java/org/example/AppPortResolutionTest.java
@@ -1,0 +1,21 @@
+package org.example;
+
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AppPortResolutionTest {
+
+    @Test
+    void cli_port_wins_over_config() {
+        int port = App.resolvePort(new String[]{"--port", "8000"}, 9090);
+        assertThat(port).isEqualTo(8000);
+    }
+
+    @Test
+    void config_port_used_when_no_cli_arg() {
+        int port = App.resolvePort(new String[]{}, 9090);
+        assertThat(port).isEqualTo(9090);
+    }
+}


### PR DESCRIPTION
CLI (`--port`) overrides config (`ConnectionConfig.properties`) and default port (8080).
Includes unit test for CLI priority.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Swedish port configuration guide describing port selection priority, default 8080, config location, YAML example, and CLI usage.
* **New Features**
  * Server now respects a --port CLI option which takes precedence over configured/default port.
* **Tests**
  * Added tests verifying CLI-overrides-config and config-used-when-no-CLI scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->