### PR TITLE
Add Bucket4j dependency in pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,13 +14,15 @@
         <junit.jupiter.version>6.0.2</junit.jupiter.version>
         <assertj.core.version>3.27.7</assertj.core.version>
         <mockito.version>5.21.0</mockito.version>
+        <bucket4j.version>8.14.0</bucket4j.version>
+
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.bucket4j</groupId>
             <artifactId>bucket4j_jdk17-core</artifactId>
-            <version>8.16.1</version>
+            <version>${bucket4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
To implement token bucket algorithm for rate limiting filter following dependency needs to be added to the pom file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added and pinned a new project dependency (bucket4j v8.14.0) to the build configuration.
  * Updated dependency management to ensure consistent builds across environments.
  * No immediate user-facing feature changes; this prepares the project for upcoming enhancements and stability improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->