### PR TITLE
Content-length and Received bytes fix

### DIFF
--- a/src/main/java/org/example/StaticFileHandler.java
+++ b/src/main/java/org/example/StaticFileHandler.java
@@ -48,8 +48,9 @@ public class StaticFileHandler {
         response.setStatusCode(statusCode);
         response.setHeaders(Map.of("Content-Type", "text/html; charset=utf-8"));
         response.setBody(fileBytes);
-        PrintWriter writer = new PrintWriter(outputStream, true);
-        writer.println(response.build());
+        PrintWriter writer = new PrintWriter(outputStream);
+        writer.print(response.build());
+        writer.flush();
 
     }
 

--- a/www/index.html
+++ b/www/index.html
@@ -9,4 +9,3 @@
 <p>Greetings from StaticFileHandler.</p>
 </body>
 </html>
-


### PR DESCRIPTION
fix PrintWriter added another line which was not calculated for body length in responseBuilder.

Replaced with manual writer flushing because the autoFlush only trigger with [ println, printf, format ] anyway.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal response handling improvements for more explicit control
  * Code formatting cleanup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->