### PR TITLE
Fix path in Dockerfile for `www` directory copy operation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,6 @@ RUN addgroup -S appgroup && adduser -S appuser -G appgroup
 WORKDIR /app/
 COPY --from=build /build/target/classes/ /app/
 COPY --from=build /build/target/dependency/ /app/dependencies/
-COPY www/ /www/
+COPY www/ ./www/
 USER appuser
 ENTRYPOINT ["java", "-classpath", "/app:/app/dependencies/*", "org.example.App"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to fix asset copy paths so application assets are placed correctly inside the container during image build. This improves consistency of built images and reduces potential missing-resource issues when running the container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->