### PR TITLE
Set `Allow` header to "GET" for 405 responses in `StaticFileHandler'

### DIFF
--- a/src/main/java/org/example/StaticFileHandler.java
+++ b/src/main/java/org/example/StaticFileHandler.java
@@ -29,6 +29,7 @@ public class StaticFileHandler implements org.example.server.TerminalHandler {
             fileBytes = "405 Method Not Allowed".getBytes(java.nio.charset.StandardCharsets.UTF_8);
             response.setContentType(TEXT_PLAIN_CHARSET_UTF_8);
             response.setStatusCode(SC_METHOD_NOT_ALLOWED);
+            response.setHeader("Allow", "GET");
             response.setBody(fileBytes);
             return;
         }

--- a/src/test/java/org/example/StaticFileHandlerTest.java
+++ b/src/test/java/org/example/StaticFileHandlerTest.java
@@ -155,5 +155,6 @@ class StaticFileHandlerTest {
 
         assertEquals(SC_METHOD_NOT_ALLOWED, responseBuilder.getStatusCode());
         assertEquals("text/plain; charset=utf-8", responseBuilder.getHeader("Content-Type"));
+        assertEquals("GET", responseBuilder.getHeader("Allow"));
     }
 }


### PR DESCRIPTION
## Summary
Add `Allow: GET` to 405 (Method Not Allowed) responses for non-GET requests.

## Why
When returning HTTP 405, the server should indicate which methods are allowed. This makes the response more HTTP-compliant and clearer for clients.

## Changes
- Set `Allow: GET` header when rejecting non-GET requests with 405.
- Update the existing unit test to assert that the `Allow` header is present and correct.

## Testing
- updated mvn test
- (Optional) Manual check: send a POST request to any static resource and verify status 405 + `Allow: GET`.
Example, I checked this in Insomnia.
<img width="1102" height="306" alt="Skärmbild 2026-02-27 011054" src="https://github.com/user-attachments/assets/155e021e-f458-4bdd-ac0f-d67f8bb28d71" />
