### PR TITLE
Issue #109: Add HTTP HEAD support

### DIFF
--- a/src/main/java/org/example/ConnectionHandler.java
+++ b/src/main/java/org/example/ConnectionHandler.java
@@ -81,7 +81,13 @@ public class ConnectionHandler implements AutoCloseable {
         }
 
         resolveTargetFile(parser.getUri());
-        sfh.sendGetRequest(client.getOutputStream(), uri);
+
+        // Handle GET vs HEAD
+        if ("HEAD".equalsIgnoreCase(request.getMethod())) {
+            sfh.sendHeadRequest(client.getOutputStream(), uri);
+        } else {
+            sfh.sendGetRequest(client.getOutputStream(), uri);
+        }
     }
 
     private HttpResponseBuilder applyFilters(HttpRequest request) {

--- a/src/main/java/org/example/StaticFileHandler.java
+++ b/src/main/java/org/example/StaticFileHandler.java
@@ -66,4 +66,14 @@ public class StaticFileHandler {
         outputStream.write(response.build());
         outputStream.flush();
     }
+    // New method for HEAD support: headers only
+    public void sendHeadRequest(OutputStream outputStream, String uri) throws IOException {
+        handleGetRequest(uri); // Reuse GET to compute status and headers
+        HttpResponseBuilder response = new HttpResponseBuilder();
+        response.setStatusCode(statusCode);
+        response.setContentTypeFromFilename(uri);
+        response.setBody(new byte[0]); // Suppress body
+        outputStream.write(response.build());
+        outputStream.flush();
+    }
 }

--- a/src/main/java/org/example/StaticFileHandler.java
+++ b/src/main/java/org/example/StaticFileHandler.java
@@ -72,6 +72,7 @@ public class StaticFileHandler {
         HttpResponseBuilder response = new HttpResponseBuilder();
         response.setStatusCode(statusCode);
         response.setContentTypeFromFilename(uri);
+        response.setHeader("Content-Length", String.valueOf(fileBytes.length));
         response.setBody(new byte[0]); // Suppress body
         outputStream.write(response.build());
         outputStream.flush();


### PR DESCRIPTION
This PR adds support for the HTTP HEAD method. HEAD requests now return the same status code and headers as GET requests, but without a response body. Existing GET functionality remains unchanged, and error responses follow the same behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Properly support HTTP HEAD requests: responses now include correct headers and content-length but omit the response body, improving protocol behavior while preserving existing GET responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->